### PR TITLE
update go version in Dockerfile-alpine

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23.1 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Update docker version from `1.22` to `1.23.1` in `Dockerfile-alpine` to fix vulnerability. Latest scan results:

![image](https://github.com/user-attachments/assets/26807092-b73e-46b4-8779-6ea6c45fe659)
